### PR TITLE
Fix edge case that currently leads to `NaN`s when z-score normalizing

### DIFF
--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -43,6 +43,8 @@ function normalize!(field, z_score::ZScore)
     field .-= z_score.μ
     if z_score.σ != 0
         field ./= z_score.σ
+    else
+        @warn "data seems to be all zeros -- just saying"
     end
     return nothing
 end

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -41,7 +41,9 @@ end
 
 function normalize!(field, z_score::ZScore)
     field .-= z_score.μ
-    field ./= z_score.σ
+    if z_score.σ != 0
+        field ./= z_score.σ
+    end
     return nothing
 end
 


### PR DESCRIPTION
When z-score normalizing a field of all zeros, we inadvertently produce `NaN`s. This fix only divides the field values if the standard deviation is nonzero.