### PR TITLE
Correct visual in perfect catke calibration example

### DIFF
--- a/examples/perfect_catke_calibration.jl
+++ b/examples/perfect_catke_calibration.jl
@@ -189,7 +189,7 @@ save("perfect_catke_calibration_summary.svg", fig); nothing #hide
 # ![](perfect_catke_calibration_summary.svg)
 
 final_mean_θ = eki.iteration_summaries[end].ensemble_mean
-forward_run!(calibration, θ★)
+forward_run!(calibration, [θ★, final_mean_θ])
 
 time_series_collector = calibration.time_series_collector
 times = time_series_collector.times


### PR DESCRIPTION
Just a one-line fix--the second-to-last plot in the perfect CATKE example was showing fields with `θ★` in place of `⟨θ⟩`.