### PR TITLE
`RescaledZScore` normalization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OceanTurbulenceParameterEstimation"
 uuid = "eca81dc5-87a6-4430-aec8-c76695404a43"
 license = "MIT"
 authors = ["Adeline Hillier <adelineh2000@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <navidcy@gmail.com>", "and co-contributors"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/examples/intro_to_inverse_problems.jl
+++ b/examples/intro_to_inverse_problems.jl
@@ -33,7 +33,7 @@ using JLD2
 examples_path = joinpath(pathof(OceanTurbulenceParameterEstimation), "..", "..", "examples")
 include(joinpath(examples_path, "intro_to_observations.jl"))
 data_path = generate_synthetic_observations()
-observations = SyntheticObservations(data_path, field_names=:b, normalize=ZScore)
+observations = SyntheticObservations(data_path, field_names=:b, normalization=ZScore())
 
 # # Building an "ensemble simulation"
 #

--- a/examples/intro_to_observations.jl
+++ b/examples/intro_to_observations.jl
@@ -85,16 +85,16 @@ data_path = generate_synthetic_observations()
 #
 # For example, to build observations with a single field we write,
 
-single_field_observations = SyntheticObservations(data_path, field_names=:b, normalize=ZScore)
+single_field_observations = SyntheticObservations(data_path, field_names=:b, normalization=ZScore())
 
 # To build observations with two fields we write
 
-two_field_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalize=ZScore)
+two_field_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization()=ZScore())
 
 # And to build observations with specified times we write
 
 times = single_field_observations.times[2:end]
-specified_times_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalize=ZScore, times=times)
+specified_times_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=ZScore(), times=times)
 
 # Notice that in the last case, `specified_times_observations.times` is missing `0.0`.
 
@@ -102,7 +102,7 @@ specified_times_observations = SyntheticObservations(data_path, field_names=(:u,
 
 # For this we include the initial condition and ``v`` velocity component,
 
-observations = SyntheticObservations(data_path, field_names=(:u, :v, :b), normalize=ZScore)
+observations = SyntheticObservations(data_path, field_names=(:u, :v, :b), normalization=ZScore())
 
 fig = Figure()
 

--- a/examples/intro_to_observations.jl
+++ b/examples/intro_to_observations.jl
@@ -89,7 +89,7 @@ single_field_observations = SyntheticObservations(data_path, field_names=:b, nor
 
 # To build observations with two fields we write
 
-two_field_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization()=ZScore())
+two_field_observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=ZScore())
 
 # And to build observations with specified times we write
 

--- a/examples/lesbrary_catke_calibration.jl
+++ b/examples/lesbrary_catke_calibration.jl
@@ -27,7 +27,13 @@ data_path = datadep"two_day_suite_4m/strong_wind_instantaneous_statistics.jld2"
 times = [2hours, 6hours, 12hours]
 field_names = (:b, :u, :v, :e)
 
-observations = SyntheticObservations(data_path; field_names, times, normalization=ZScore())
+## Use a special normalization that emphasizes buoyancy and de-emphasizes TKE
+normalization = (b = ZScore(),
+                 u = RescaledZScore(0.1), 
+                 v = RescaledZScore(0.1), 
+                 e = RescaledZScore(0.01)) 
+
+observations = SyntheticObservations(data_path; field_names, times, normalization)
 
 # Let's take a look at the observations. We define a few
 # plotting utilities along the way to use later in the example:
@@ -65,7 +71,7 @@ end
 
 [axislegend(ax, position=:rb, merge=true, fontsize=10) for ax in axs]
 
-## display(fig)
+display(fig)
 save("lesbrary_synthetic_observations.svg", fig); nothing # hide
 
 # ![](lesbrary_synthetic_observations.svg)
@@ -153,7 +159,7 @@ initial_parameters = eki.iteration_summaries[0].ensemble_mean
 forward_run!(calibration, initial_parameters)
 fig = compare_model_observations("modeled after 0 iterations")
 
-## display(fig)
+display(fig)
 save("model_observation_comparison_iteration_0.svg", fig); nothing # hide
 
 # ![](model_observation_comparison_iteration_0.svg)
@@ -164,7 +170,7 @@ best_parameters = eki.iteration_summaries[end].ensemble_mean
 forward_run!(calibration, best_parameters)
 fig = compare_model_observations("modeled after $Niter iterations")
 
-## display(fig)
+display(fig)
 save("model_observation_comparison_final_iteration.svg", fig); nothing # hide
 
 # ![](model_observation_comparison_final_iteration.svg)
@@ -189,7 +195,7 @@ end
 
 axislegend(ax, position=:rb)
 
-## display(fig)
+display(fig)
 save("lesbrary_catke_parameter_evolution.svg", fig); nothing # hide
 
 # ![](lesbrary_catke_parameter_evolution.svg)

--- a/examples/lesbrary_catke_calibration.jl
+++ b/examples/lesbrary_catke_calibration.jl
@@ -132,7 +132,7 @@ eki = EnsembleKalmanInversion(calibration;
                               noise_covariance = 1e-2,
                               resampler = NaNResampler(abort_fraction=0.5))
 
-iterate!(eki; iterations = 20)
+iterate!(eki; iterations = 5)
 
 # # Results
 #

--- a/examples/lesbrary_catke_calibration.jl
+++ b/examples/lesbrary_catke_calibration.jl
@@ -29,9 +29,9 @@ field_names = (:b, :u, :v, :e)
 
 ## Use a special normalization that emphasizes buoyancy and de-emphasizes TKE
 normalization = (b = ZScore(),
-                 u = RescaledZScore(0.1), 
-                 v = RescaledZScore(0.1), 
-                 e = RescaledZScore(0.01)) 
+                 u = ZScore(), 
+                 v = ZScore(), 
+                 e = RescaledZScore(0.1)) 
 
 observations = SyntheticObservations(data_path; field_names, times, normalization)
 

--- a/examples/lesbrary_catke_calibration.jl
+++ b/examples/lesbrary_catke_calibration.jl
@@ -12,8 +12,6 @@ using Oceananigans.Units
 using OceanTurbulenceParameterEstimation
 using LinearAlgebra, CairoMakie, DataDeps
 
-using ElectronDisplay
-
 using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities:
     CATKEVerticalDiffusivity, MixingLength
 
@@ -71,7 +69,6 @@ end
 
 [axislegend(ax, position=:rb, merge=true, fontsize=10) for ax in axs]
 
-display(fig)
 save("lesbrary_synthetic_observations.svg", fig); nothing # hide
 
 # ![](lesbrary_synthetic_observations.svg)
@@ -159,7 +156,6 @@ initial_parameters = eki.iteration_summaries[0].ensemble_mean
 forward_run!(calibration, initial_parameters)
 fig = compare_model_observations("modeled after 0 iterations")
 
-display(fig)
 save("model_observation_comparison_iteration_0.svg", fig); nothing # hide
 
 # ![](model_observation_comparison_iteration_0.svg)
@@ -170,7 +166,6 @@ best_parameters = eki.iteration_summaries[end].ensemble_mean
 forward_run!(calibration, best_parameters)
 fig = compare_model_observations("modeled after $Niter iterations")
 
-display(fig)
 save("model_observation_comparison_final_iteration.svg", fig); nothing # hide
 
 # ![](model_observation_comparison_final_iteration.svg)
@@ -195,7 +190,6 @@ end
 
 axislegend(ax, position=:rb)
 
-display(fig)
 save("lesbrary_catke_parameter_evolution.svg", fig); nothing # hide
 
 # ![](lesbrary_catke_parameter_evolution.svg)

--- a/examples/lesbrary_catke_calibration.jl
+++ b/examples/lesbrary_catke_calibration.jl
@@ -27,7 +27,7 @@ data_path = datadep"two_day_suite_4m/strong_wind_instantaneous_statistics.jld2"
 times = [2hours, 6hours, 12hours]
 field_names = (:b, :u, :v, :e)
 
-observations = SyntheticObservations(data_path; field_names, times, normalize=ZScore)
+observations = SyntheticObservations(data_path; field_names, times, normalization=ZScore())
 
 # Let's take a look at the observations. We define a few
 # plotting utilities along the way to use later in the example:

--- a/examples/perfect_baroclinic_adjustment_calibration.jl
+++ b/examples/perfect_baroclinic_adjustment_calibration.jl
@@ -122,7 +122,7 @@ end
 
 # ## Load truth data as observations
 
-observations = SyntheticObservations(data_path, field_names=(:b, :c), normalize=ZScore)
+observations = SyntheticObservations(data_path, field_names=(:b, :c), normalization=ZScore())
 
 # ## Calibration with Ensemble Kalman Inversion
 

--- a/examples/perfect_catke_calibration.jl
+++ b/examples/perfect_catke_calibration.jl
@@ -51,7 +51,7 @@ data_path = generate_synthetic_observations("catke",
 
 # Next, we load and inspect the observations to make sure they're sensible:
 
-observations = SyntheticObservations(data_path, field_names=(:u, :v, :b, :e), normalize=ZScore)
+observations = SyntheticObservations(data_path, field_names=(:u, :v, :b, :e), normalization=ZScore())
 
 fig = Figure()
 

--- a/examples/perfect_convective_adjustment_calibration.jl
+++ b/examples/perfect_convective_adjustment_calibration.jl
@@ -27,7 +27,7 @@ examples_path = joinpath(pathof(OceanTurbulenceParameterEstimation), "..", "..",
 include(joinpath(examples_path, "intro_to_inverse_problems.jl"))
 
 data_path = generate_synthetic_observations()
-observations = SyntheticObservations(data_path, field_names=:b, normalize=ZScore)
+observations = SyntheticObservations(data_path, field_names=:b, normalization=ZScore())
 
 # and an ensemble_simulation,
 

--- a/examples/two_case_catke_calibration.jl
+++ b/examples/two_case_catke_calibration.jl
@@ -30,8 +30,8 @@ non_rotating_data_path = datadep"two_day_suite_4m/strong_wind_no_rotation_instan
 times = [2hours, 6hours, 18hours]
 
 field_names = field_names = (:u, :v, :b, :e)
-normalize = ZScore
-observations = [SyntheticObservations(data_path; field_names, normalize, times)
+normalization = ZScore()
+observations = [SyntheticObservations(data_path; field_names, normalization, times)
                 for data_path in (rotating_data_path, non_rotating_data_path)]
 
 # Let's take a look at the observations. We define a few

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -208,12 +208,17 @@ function transform_time_series(output_map::ConcatenatedOutputMap, time_series::S
 
     for field_name in keys(time_series.field_time_serieses)
         field_time_series = time_series.field_time_serieses[field_name]
+
+        # Copy time series data to `Array`, keeping only `time_indices` and discarding halos
         field_time_series_data = Array(interior(field_time_series))[:, :, :, output_map.time_indices]
 
+        # Reshape data to 2D array with size (Nx, :)
         Nx, Ny, Nz, Nt = size(field_time_series_data)
         field_time_series_data = reshape(field_time_series_data, Nx, Ny * Nz * Nt)
 
+        # Normalize data according to observation-specified normalization
         normalize!(field_time_series_data, time_series.normalization[field_name])
+
         push!(flattened_normalized_data, field_time_series_data)
     end
 

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -212,12 +212,12 @@ function transform_time_series(output_map::ConcatenatedOutputMap, time_series::S
         # Copy time series data to `Array`, keeping only `time_indices` and discarding halos
         field_time_series_data = Array(interior(field_time_series))[:, :, :, output_map.time_indices]
 
+        # Normalize data according to observation-specified normalization
+        normalize!(field_time_series_data, time_series.normalization[field_name])
+
         # Reshape data to 2D array with size (Nx, :)
         Nx, Ny, Nz, Nt = size(field_time_series_data)
         field_time_series_data = reshape(field_time_series_data, Nx, Ny * Nz * Nt)
-
-        # Normalize data according to observation-specified normalization
-        normalize!(field_time_series_data, time_series.normalization[field_name])
 
         push!(flattened_normalized_data, field_time_series_data)
     end

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -116,7 +116,7 @@ function observation_times(obs::Vector)
 end
 
 function SyntheticObservations(path; field_names,
-                               normalization = IdentityNormalization,
+                               normalization = IdentityNormalization(),
                                times = nothing,
                                field_time_serieses = nothing,
                                regrid_size = nothing)
@@ -170,7 +170,7 @@ function SyntheticObservations(path; field_names,
     close(file)
 
     normalization = field_named_tuple(normalization, field_names, "normalization")
-    normalization = Dict(name => compute_normalization!(normalization[name], field_time_serieses[name])
+    normalization = Dict(name => compute_normalization_properties!(normalization[name], field_time_serieses[name])
                          for name in keys(field_time_serieses))
 
     return SyntheticObservations(field_time_serieses, grid, times, path, metadata, normalization)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -12,6 +12,8 @@ using JLD2
 
 import Oceananigans.Fields: set!
 
+using OceanTurbulenceParameterEstimation.Utils: field_named_tuple
+
 abstract type AbstractObservation end
 
 include("normalization.jl")
@@ -114,7 +116,7 @@ function observation_times(obs::Vector)
 end
 
 function SyntheticObservations(path; field_names,
-                               normalize = IdentityNormalization,
+                               normalization = IdentityNormalization,
                                times = nothing,
                                field_time_serieses = nothing,
                                regrid_size = nothing)
@@ -167,7 +169,9 @@ function SyntheticObservations(path; field_names,
     metadata = NamedTuple(Symbol(group) => read_group(file[group]) for group in filter(n -> n ∉ not_metadata_names, keys(file)))
     close(file)
 
-    normalization = Dict(name => normalize(field_time_serieses[name]) for name in keys(field_time_serieses))
+    normalization = field_named_tuple(normalization, field_names, "normalization")
+    normalization = Dict(name => compute_normalization!(normalization[name], field_time_serieses[name])
+                         for name in keys(field_time_serieses))
 
     return SyntheticObservations(field_time_serieses, grid, times, path, metadata, normalization)
 end

--- a/src/OceanTurbulenceParameterEstimation.jl
+++ b/src/OceanTurbulenceParameterEstimation.jl
@@ -5,6 +5,7 @@ export
     InverseProblem,
     FreeParameters,
     IdentityNormalization,
+    RescaledZScore,
     ZScore,
     forward_map,
     forward_run!,
@@ -31,7 +32,9 @@ include("EnsembleKalmanInversions.jl")
 
 using .Observations:
     SyntheticObservations,
+    IdentityNormalization,
     ZScore,
+    RescaledZScore,
     observation_times
 
 using .EnsembleSimulations: ensemble_column_model_simulation

--- a/src/OceanTurbulenceParameterEstimation.jl
+++ b/src/OceanTurbulenceParameterEstimation.jl
@@ -22,6 +22,7 @@ export
     SuccessfulEnsembleDistribution,
     ConstrainedNormal
 
+include("Utils.jl")
 include("Observations.jl")
 include("EnsembleSimulations.jl")
 include("TurbulenceClosureParameters.jl")

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,0 +1,18 @@
+module Utils
+
+field_named_tuple(value, field_names, args...) = NamedTuple(name => value for name in field_names)
+field_named_tuple(t::Tuple, field_names, args...) = NamedTuple(name => t[i] for (i, name) in enumerate(field_names))
+
+function field_named_tuple(nt::NamedTuple, field_names, nt_name="")
+    nt_field_names = keys(nt)
+    nt_summary = summary(nt)
+
+    # Validate user-supplied NamedTuple
+    nt_field_names === field_names ||
+        throw(ArgumentError("$nt_name $nt_summary must have values for every field in $field_names " *
+                            " but only has values for $nt_field_names"))
+
+    return nt
+end
+
+end # module

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -10,7 +10,8 @@ function variance(field)
     return variance
 end
 
-mean_variance(field_time_series) = mean((variance(field_time_series[i]) for i = 1:length(field_time_series.times)))
+mean_variance(field_time_series) = mean((variance(field_time_series[i])
+                                         for i = 1:length(field_time_series.times)))
 
 #####
 ##### Identity normalization
@@ -23,7 +24,8 @@ struct IdentityNormalization end
 
 Compute `normalization` properties for `field_time_series`.
 """
-compute_normalization_properties!(::IdentityNormalization, fts) = IdentityNormalization()
+compute_normalization_properties!(::IdentityNormalization, fts) =
+    IdentityNormalization()
 
 """
     normalize!(field, normalization)
@@ -68,6 +70,26 @@ compute_normalization_properties!(::ZScore, fts) = ZScore(fts)
 function normalize!(field, normalization::ZScore)
     μ, σ = normalization.μ, normalization.σ
     field .= (field .- μ) ./ σ
+    return nothing
+end
+
+#####
+##### ZScore normalization
+#####
+
+struct RescaledZScore{T, Z}
+    scale :: T
+    zscore :: Z
+end
+
+RescaledZScore(scale) = RescaledZScore(scale, nothing)
+
+compute_normalization_properties!(r::RescaledZScore, fts) =
+    RescaledZScore(r.scale, ZScore(fts))
+
+function normalize!(field, normalization::RescaledZScore)
+    normalize!(field, normalization.zscore)
+    field .*= normalization.scale
     return nothing
 end
 

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -10,32 +10,20 @@ function variance(field)
     return variance
 end
 
-#=
-function Base.iterate(field_time_series::FieldTimeSeries, state)
-    if state >= length(field_time_series.times)
-        return nothing
-    else
-        return field_time_series[state+1], state+1
-    end
-end
-=#
-
 mean_variance(field_time_series) = mean((variance(field_time_series[i]) for i = 1:length(field_time_series.times)))
 
 #####
-##### Normalization functionality for forward map output
+##### Identity normalization
 #####
 
-abstract type AbstractNormalization end
+struct IdentityNormalization end
 
-struct IdentityNormalization <: AbstractNormalization end
+"""
+    compute_normalization_properties!(normalization, field_time_series)
 
-IdentityNormalization(field_time_series) = IdentityNormalization()
-
-struct ZScore{T} <: AbstractNormalization
-    μ :: T
-    σ :: T
-end
+Compute `normalization` properties for `field_time_series`.
+"""
+compute_normalization_properties!(::IdentityNormalization, fts) = IdentityNormalization()
 
 """
     normalize!(field, normalization)
@@ -44,27 +32,16 @@ Normalize `field` using `normalization`.
 """
 normalize!(field, ::IdentityNormalization) = nothing
 
-function normalize!(field, normalization::ZScore)
-    field .-= normalization.μ
+#####
+##### ZScore normalization
+#####
 
-    if normalization.σ != 0
-        field ./= normalization.σ
-    else
-        @warn "Field data seems to be all zeros -- just saying."
-    end
-
-    return nothing
+struct ZScore{T}
+    μ :: T
+    σ :: T
 end
 
-#=
-"Returns a view of `f` that excludes halo points."
-@inline interior(f::FieldTimeSeries{X, Y, Z}) where {X, Y, Z} =
-    view(parent(f.data),
-         interior_parent_indices(X, topology(f, 1), f.grid.Nx, f.grid.Hx),
-         interior_parent_indices(Y, topology(f, 2), f.grid.Ny, f.grid.Hy),
-         interior_parent_indices(Z, topology(f, 3), f.grid.Nz, f.grid.Hz),
-         :)
-=#
+ZScore() = ZScore(nothing, nothing) # stub for user-interface
 
 """
     ZScore(field_time_series::FieldTimeSeries)
@@ -75,6 +52,22 @@ its mean and its variance.
 function ZScore(field_time_series::FieldTimeSeries)
     μ = mean(interior(field_time_series))
     σ = sqrt(mean_variance(field_time_series))
-    
+
+    if σ == 0
+        @warn("Field data seems to be all zeros --- just sayin'. Setting " *
+              "ZScore standard deviation to 1.")
+
+        σ = one(μ)
+    end
+
     return ZScore(μ, σ)
 end
+
+compute_normalization_properties!(::ZScore, fts) = ZScore(fts)
+
+function normalize!(field, normalization::ZScore)
+    μ, σ = normalization.μ, normalization.σ
+    field .= (field .- μ) ./ σ
+    return nothing
+end
+

--- a/src/normalization.jl
+++ b/src/normalization.jl
@@ -69,7 +69,7 @@ compute_normalization_properties!(::ZScore, fts) = ZScore(fts)
 
 function normalize!(field, normalization::ZScore)
     μ, σ = normalization.μ, normalization.σ
-    field .= (field .- μ) ./ σ
+    @. field = (field - μ) / σ
     return nothing
 end
 
@@ -89,7 +89,7 @@ compute_normalization_properties!(r::RescaledZScore, fts) =
 
 function normalize!(field, normalization::RescaledZScore)
     normalize!(field, normalization.zscore)
-    field .*= normalization.scale
+    @. field *= normalization.scale
     return nothing
 end
 

--- a/test/test_forward_map.jl
+++ b/test/test_forward_map.jl
@@ -57,7 +57,7 @@ using OceanTurbulenceParameterEstimation.InverseProblems: transpose_model_output
     run!(truth_simulation)
 
     data_path = experiment_name * ".jld2"
-    observations = SyntheticObservations(data_path, field_names=(:u, :b), normalize=ZScore)
+    observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=ZScore())
     
     #####
     ##### Make model data

--- a/test/test_forward_map.jl
+++ b/test/test_forward_map.jl
@@ -57,7 +57,7 @@ using OceanTurbulenceParameterEstimation.InverseProblems: transpose_model_output
     run!(truth_simulation)
 
     data_path = experiment_name * ".jld2"
-    observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=ZScore())
+    observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=(u=RescaledZScore(0.1), b=ZScore()))
     
     #####
     ##### Make model data
@@ -67,7 +67,6 @@ using OceanTurbulenceParameterEstimation.InverseProblems: transpose_model_output
         # First test transpose_model_output
         test_simulation = build_simulation()
         collected_fields = (u = test_simulation.model.velocities.u, b = test_simulation.model.tracers.b)
-
         time_series_collector = FieldTimeSeriesCollector(collected_fields, observation_times(observations))
 
         # Test initialize_simulation!

--- a/test/test_synthetic_observations.jl
+++ b/test/test_synthetic_observations.jl
@@ -86,10 +86,10 @@ using Oceananigans.TurbulenceClosures: ConvectiveAdjustmentVerticalDiffusivity
 
     normalization = (u = IdentityNormalization(), v = ZScore(), b = RescaledZScore(0.1))
     uvb_observations = SyntheticObservations(data_path; field_names, normalization)
-    @test uvb.normalization[:u] isa IdentityNormalization
-    @test uvb.normalization[:v] isa ZScore
-    @test uvb.normalization[:b] isa RescaledZScore
-    @test uvb.normalization[:b].scale === 0.1
+    @test uvb_observations.normalization[:u] isa IdentityNormalization
+    @test uvb_observations.normalization[:v] isa ZScore
+    @test uvb_observations.normalization[:b] isa RescaledZScore
+    @test uvb_observations.normalization[:b].scale === 0.1
 
     # Regridding
     coarsened_observations = SyntheticObservations(data_path, field_names=(:u, :v, :b), regrid_size=(1, 1, Int(Nz/2)))


### PR DESCRIPTION
This PR refactors the user interface for normalization and introduces a `RescaledZScore` type for further scaling a field up/down after computing the `ZScore` normalization:

https://github.com/CliMA/OceanTurbulenceParameterEstimation.jl/blob/42d9765f297c3d572b2079ee501ac8f410e344a3/src/normalization.jl#L90-L94

The new interface changes the kwarg `normalize` in `SyntheticObservations` to `normalization`. This kwarg now accepts _instances_ rather than types, because we need to use `instances` to store user-supplied information like the `scale` factor in `RescaledZScore`:

https://github.com/CliMA/OceanTurbulenceParameterEstimation.jl/blob/42d9765f297c3d572b2079ee501ac8f410e344a3/test/test_forward_map.jl#L60

One more thing: the constructor for `SyntheticObservations` previously took a single `normalize` and applied it to all fields. But with this PR we want to introduce the concept that different fields might be normalized differently. So we need to design an API for that. Here I implemented an API that allows two input modes:

1. singleton `normalization`, which is applied to all fields
2. `NamedTuple` `normalization`, for which _all_ fields must be provided

Example 1:

```julia
# ZScore applied to :u _and_ :b 
observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=ZScore())
```

Example 2:

```julia
# RescaledZScore applied to :u and ZScore applied to :b
observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=(u=RescaledZScore(0.1), b=ZScore()))
```

An alternative to 2. might instead use some "default" value for the fields that are not included in the `normalization` `NamedTuple`, eg

```julia
# Default applied to b
observations = SyntheticObservations(data_path, field_names=(:u, :b), normalization=(; u=RescaledZScore(0.1)))
```

The way it is now is more explicit (and not too onerous since the number of fields is small, but the alternative could be more user-friendly if we are going to use `ZScore` in the vast majority of cases. Thoughts?

_Another idea_: we can interpret the key `:default` in a special manner and apply it to all fields that don't have explicit values... ?

TODO:
- [x] Tests