### PR TITLE
Calibrate `IsopycnalSkewSymmetricDiffusivity` in eddying channel

### DIFF
--- a/examples/calibrate_zonally_averaged_channel.jl
+++ b/examples/calibrate_zonally_averaged_channel.jl
@@ -13,15 +13,15 @@ using Oceananigans
 using Oceananigans.Units
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: SliceEnsembleSize
 using Oceananigans.TurbulenceClosures: FluxTapering
-using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities:
-    CATKEVerticalDiffusivity
 
-using LinearAlgebra, CairoMakie, DataDeps, Distributions
+using LinearAlgebra, CairoMakie, DataDeps, Distributions, JLD2
 
 using ElectronDisplay
 
 architecture = CPU()
 
+# download from https://www.dropbox.com/s/91altratyy1g0fc/eddying_channel_catke_zonal_average.jld2?dl=0
+# and change path below accordingly
 filepath = "/Users/navid/Research/mesoscale-parametrization-OSM2022/eddying_channel/Ny200Nx100_Lx1000_Ly2000/eddying_channel_catke_zonal_average.jld2"
 
 b_timeseries = FieldTimeSeries(filepath, "b")
@@ -54,7 +54,7 @@ const Ly, Lz= file["grid/Ly"], file["grid/Lz"]
 # number of grid points
 Ny, Nz= file["grid/Ny"], file["grid/Nz"]
 
-Nensemble = 20
+Nensemble = 6
 
 slice_ensemble_size = SliceEnsembleSize(size=(Ny, Nz), ensemble=Nensemble)
 
@@ -84,6 +84,7 @@ ensemble_model = HydrostaticFreeSurfaceModel(grid = ensemble_grid,
                                              closure = closure_ensemble,
                                              free_surface = ImplicitFreeSurface(),
                                              )
+
 #=
 
 Δt = 5minute              # time-step

--- a/examples/calibrate_zonally_averaged_channel.jl
+++ b/examples/calibrate_zonally_averaged_channel.jl
@@ -1,0 +1,108 @@
+# # Perfect CAKTE calibration with Ensemble Kalman Inversion
+
+# ## Install dependencies
+
+# ```julia
+# using Pkg
+# pkg"add OceanTurbulenceParameterEstimation, Oceananigans, Distributions, CairoMakie"
+# ```
+
+using OceanTurbulenceParameterEstimation
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: SliceEnsembleSize
+using Oceananigans.TurbulenceClosures: FluxTapering
+using Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivities:
+    CATKEVerticalDiffusivity
+
+using LinearAlgebra, CairoMakie, DataDeps, Distributions
+
+using ElectronDisplay
+
+architecture = CPU()
+
+filepath = "/Users/navid/Research/mesoscale-parametrization-OSM2022/eddying_channel/Ny200Nx100_Lx1000_Ly2000/eddying_channel_catke_zonal_average.jld2"
+
+b_timeseries = FieldTimeSeries(filepath, "b")
+
+field_names = (:b, :u, :v, :w)
+# field_names = (:b, :c, :u, :v, :w)
+
+normalization = (b = ZScore(),
+                #  c = ZScore(),
+                 u = ZScore(),
+                 v = ZScore(),
+                 w = RescaledZScore(1e-2))
+
+times = b_timeseries.times[500:10:800]
+
+observations = SyntheticObservations(filepath; normalization, times, field_names)
+     
+#####
+##### Simulation
+#####
+
+file = jldopen(filepath)
+
+coriolis = file["serialized/coriolis"]
+
+
+# Domain
+const Ly, Lz= file["grid/Ly"], file["grid/Lz"]
+
+# number of grid points
+Ny, Nz= file["grid/Ny"], file["grid/Nz"]
+
+Nensemble = 20
+
+slice_ensemble_size = SliceEnsembleSize(size=(Ny, Nz), ensemble=Nensemble)
+
+ensemble_grid = RectilinearGrid(architecture,
+                                size = slice_ensemble_size,
+                                topology = (Flat, Bounded, Bounded),
+                                y = (0, Ly),
+                                z = (-Lz, 0),
+                                halo=(3, 3))
+
+κ_skew = 1000.0       # [m² s⁻¹] skew diffusivity
+κ_symmetric = 900.0   # [m² s⁻¹] symmetric diffusivity
+
+gerdes_koberle_willebrand_tapering = FluxTapering(1e-2)
+gent_mcwilliams_diffusivity = IsopycnalSkewSymmetricDiffusivity(κ_skew = κ_skew,
+                                                                κ_symmetric = κ_symmetric,
+                                                                slope_limiter = gerdes_koberle_willebrand_tapering)
+
+closures = file["serialized/closure"]
+
+closure_ensemble = [(deepcopy(gent_mcwilliams_diffusivity), closures[1], closures[2]) for _ = 1:Nensemble]
+
+ensemble_model = HydrostaticFreeSurfaceModel(grid = ensemble_grid,
+                                             tracers = (:b, :e, :c),
+                                             buoyancy = BuoyancyTracer(),
+                                             coriolis = coriolis,
+                                             closure = closure_ensemble,
+                                             free_surface = ImplicitFreeSurface(),
+                                             )
+#=
+
+Δt = 5minute              # time-step
+stop_time = 1year         # length of run
+save_interval = 7days     # save observation every so often
+
+simulation = Simulation(ensemble_model; Δt, stop_time)
+
+# Ideally, we want to create a function ensemble_slice_model_simulation() and build
+# the simulation via, e.g., 
+
+closures = file["serialized/closure"]
+
+simulation = ensemble_slice_model_simulation(observations;
+                                             Nensemble = Nensemble,
+                                             architecture = architecture,
+                                             tracers = (:b, :e, :c),
+                                             free_closures = gent_mcwilliams_diffusivity,
+                                             additional_closures = closures::Tuple
+                                             )
+
+=#

--- a/src/TurbulenceClosureParameters.jl
+++ b/src/TurbulenceClosureParameters.jl
@@ -133,6 +133,8 @@ closure_with_parameters(closures::Tuple, parameters) =
 
 Use `parameters` to update closure from `closures` that corresponds to ensemble member `p_ensemble`.
 """
+update_closure_ensemble_member!(closure, p_ensemble, parameters) = nothing
+
 update_closure_ensemble_member!(closures::AbstractVector, p_ensemble, parameters) =
     closures[p_ensemble] = closure_with_parameters(closures[p_ensemble], parameters)
 
@@ -141,6 +143,13 @@ function update_closure_ensemble_member!(closures::AbstractMatrix, p_ensemble, p
         closures[p_ensemble, j] = closure_with_parameters(closures[p_ensemble, j], parameters)
     end
     
+    return nothing
+end
+
+function update_closure_ensemble_member!(closure_tuple::Tuple, p_ensemble, parameters)
+    for closure in closure_tuple
+        update_closure_ensemble_member!(closure, p_ensemble, parameters)
+    end
     return nothing
 end
 

--- a/test/test_turbulence_closure_parameters.jl
+++ b/test/test_turbulence_closure_parameters.jl
@@ -54,4 +54,41 @@ const CATKE = CATKEVerticalDiffusivity
     for j in 1:2
         @test closures[ensemble_member_no, j].mixing_length.CᴷRiʷ == new_CᴷRiʷ
     end
+
+    #####
+    ##### Tuples of closures
+    #####
+
+    @info "Testing closure_with_parameters on (CAVD, CATKE)"
+    
+    new_Cᴷuʳ = 1e3
+
+    closures = tuple(
+        closure_with_parameters(catke_closure, (; Cᴷuʳ = new_Cᴷuʳ)),
+        closure_with_parameters(CAVD(), (; background_κz = 1.4))
+    )
+
+    @test closures[1].mixing_length.Cᴷuʳ == new_Cᴷuʳ
+    @test closures[2].background_κz == 1.4
+
+
+
+    @info "Testing closure_with_parameters on (CAVD, [CATKE, CATKE])"
+    
+    catkes = @suppress [CATKE(), CATKE()]
+    
+    new_Cᴷuʳ = 1e3
+
+    closures = tuple(CAVD(background_κz=1.0), catkes)
+
+    new_CᴷRiʷ = 100.0
+    ensemble_member_no = 2
+
+    old_CᴷRiʷ = catkes[1].mixing_length.CᴷRiʷ
+
+    update_closure_ensemble_member!(closures, ensemble_member_no, (; CᴷRiʷ = new_CᴷRiʷ))
+
+    @test closures[1].background_κz == 1.0
+    @test closures[2][1].mixing_length.CᴷRiʷ == old_CᴷRiʷ
+    @test closures[2][ensemble_member_no].mixing_length.CᴷRiʷ == new_CᴷRiʷ
 end


### PR DESCRIPTION
This is the first attempt to calibrate `IsopycnalSkewSymmetricDiffusivity` using output from the eddying channel solution. 

I am running into problems (briefly discussed also in #158) when constructing ensemble model with more than one closures. What I would like is to create an ensemble model in which each model should have 3 closures: `CATKE` + `AnisotropicDiffusivity` that are the same for all ensemble members *and* `IsopycnalSkewSymmetricDiffusivity` that vary for each ensemble member.

cc @glwagner 