### PR TITLE
Properly export functions from submodules

### DIFF
--- a/docs/src/library/internals.md
+++ b/docs/src/library/internals.md
@@ -23,7 +23,6 @@ Pages   = ["Transformations.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.Observations]
 Public = false
-Pages   = ["Observations.jl"]
 ```
 
 ## Ensemble Simulations
@@ -31,16 +30,13 @@ Pages   = ["Observations.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.EnsembleSimulations]
 Public = false
-Pages   = ["EnsembleSimulations.jl"]
 ```
-include("InverseProblems.jl")
 
 ## Parameters
 
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.Parameters]
 Public = false
-Pages   = ["Parameters.jl"]
 ```
 
 ## Inverse Problems
@@ -48,7 +44,6 @@ Pages   = ["Parameters.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.InverseProblems]
 Public = false
-Pages   = ["InverseProblems.jl"]
 ```
 
 ## EnsembleKalmanInversions
@@ -56,5 +51,4 @@ Pages   = ["InverseProblems.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.EnsembleKalmanInversions]
 Public = false
-Pages   = ["EnsembleKalmanInversions.jl"]
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -9,7 +9,6 @@ See the Internals section of the manual for internal package docs covering all s
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation]
 Private = false
-Pages   = ["OceanTurbulenceParameterEstimation.jl"]
 ```
 
 ## Transformations
@@ -17,7 +16,6 @@ Pages   = ["OceanTurbulenceParameterEstimation.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.Transformations]
 Private = false
-Pages   = ["Transformations.jl"]
 ```
 
 ## Observations
@@ -25,7 +23,6 @@ Pages   = ["Transformations.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.Observations]
 Private = false
-Pages   = ["Observations.jl"]
 ```
 
 ## Ensemble Simulations
@@ -33,16 +30,13 @@ Pages   = ["Observations.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.EnsembleSimulations]
 Private = false
-Pages   = ["EnsembleSimulations.jl"]
 ```
-include("InverseProblems.jl")
 
 ## Parameters
 
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.Parameters]
 Private = false
-Pages   = ["Parameters.jl"]
 ```
 
 ## Inverse Problems
@@ -50,7 +44,6 @@ Pages   = ["Parameters.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.InverseProblems]
 Private = false
-Pages   = ["InverseProblems.jl"]
 ```
 
 ## EnsembleKalmanInversions
@@ -58,5 +51,4 @@ Pages   = ["InverseProblems.jl"]
 ```@autodocs
 Modules = [OceanTurbulenceParameterEstimation.EnsembleKalmanInversions]
 Private = false
-Pages   = ["EnsembleKalmanInversions.jl"]
 ```

--- a/src/EnsembleKalmanInversions.jl
+++ b/src/EnsembleKalmanInversions.jl
@@ -1,5 +1,12 @@
 module EnsembleKalmanInversions
 
+export
+    iterate!,
+    EnsembleKalmanInversion,
+    Resampler,
+    FullEnsembleDistribution,
+    SuccessfulEnsembleDistribution
+
 using OffsetArrays
 using ProgressBars
 using Random

--- a/src/EnsembleSimulations.jl
+++ b/src/EnsembleSimulations.jl
@@ -1,5 +1,7 @@
 module EnsembleSimulations
 
+export ensemble_column_model_simulation
+
 using Oceananigans
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
 using Oceananigans.Architectures: arch_array

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -344,9 +344,10 @@ end
 """
     observation_map_variance_across_time(map::ConcatenatedOutputMap, observation::SyntheticObservations)
 
-Return an (Nx, Ny*Nz*Nfields, Ny*Nz*Nfields) array storing the covariance of each element of the observation 
-map measured across time, for each ensemble member, where `Nx` is the ensemble size, `Ny` is the batch size, 
-`Nz` is the number of grid elements in the vertical, and `Nfields` is the number of fields in `observation`.
+Return an array of size `(Nensemble, Ny * Nz * Nfields, Ny * Nz * Nfields)` that stores the covariance of
+each element of the observation map measured across time, for each ensemble member, where `Nensemble` is
+the ensemble size, `Ny` is either the number of grid elements in `y` or the batch size, `Nz` is the number
+of grid elements in the vertical, and `Nfields` is the number of fields in `observation`.
 """
 function observation_map_variance_across_time(map::ConcatenatedOutputMap, observation::SyntheticObservations)
     # These aren't right because every field can have a different transformation, so...

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -1,5 +1,13 @@
 module InverseProblems
 
+export
+    InverseProblem,
+    forward_map,
+    forward_run!,
+    observation_map,
+    observation_map_variance_across_time,
+    ConcatenatedOutputMap
+
 using OrderedCollections
 using Suppressor: @suppress
 

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -51,10 +51,10 @@ end
 
 """
     InverseProblem(observations,
-                        simulation,
-                        free_parameters;
-                        output_map = ConcatenatedOutputMap(),
-                        time_series_collector = nothing)
+                simulation,
+                free_parameters;
+                output_map = ConcatenatedOutputMap(),
+                time_series_collector = nothing)
 
 Return an `InverseProblem`.
 """
@@ -137,7 +137,11 @@ Nobservations(grid::TwoDimensionalEnsembleGrid) = 1
 Nensemble(grid::Union{OneDimensionalEnsembleGrid, TwoDimensionalEnsembleGrid}) = grid.Nx
 Nensemble(ip::InverseProblem) = Nensemble(ip.simulation.model.grid)
 
-""" Transform and return `ip.observations` appropriate for `ip.output_map`. """
+"""
+    observation_map(ip::InverseProblem)
+
+Transform and return `ip.observations` appropriately for `ip.output_map`.
+"""
 observation_map(ip::InverseProblem) = transform_time_series(ip.output_map, ip.observations)
 
 """
@@ -380,4 +384,3 @@ observation_map_variance_across_time(map::ConcatenatedOutputMap, observations::V
 observation_map_variance_across_time(ip::InverseProblem) = observation_map_variance_across_time(ip.output_map, ip.observations)
 
 end # module
-

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -107,27 +107,27 @@ function SyntheticObservations(path=nothing; field_names,
     return SyntheticObservations(field_time_serieses, grid, times, path, metadata, transformation)
 end
 
-observation_names(ts::SyntheticObservations) = keys(ts.field_time_serieses)
+observation_names(observations::SyntheticObservations) = keys(observations.field_time_serieses)
 
 """
-    observation_names(obs::Vector{<:SyntheticObservations})
+    observation_names(observations::Vector{<:SyntheticObservations})
 
 Return a Set representing the union of all names in `obs`.
 """
-function observation_names(obs_vector::Vector{<:SyntheticObservations})
+function observation_names(observations::Vector{<:SyntheticObservations})
     names = Set()
-    for obs in obs_vector
+    for obs in observations
         push!(names, observation_names(obs)...)
     end
 
     return names
 end
 
-Base.summary(obs::SyntheticObservations) =
-    "SyntheticObservations of $(keys(obs.field_time_serieses)) on $(summary(obs.grid))"
+Base.summary(observations::SyntheticObservations) =
+    "SyntheticObservations of $(keys(observations.field_time_serieses)) on $(summary(observations.grid))"
 
-Base.summary(obs::Vector{<:SyntheticObservations}) =
-    "Vector{<:SyntheticObservations} of $(keys(first(obs).field_time_serieses)) on $(summary(first(obs).grid))"
+Base.summary(observations::Vector{<:SyntheticObservations}) =
+    "Vector{<:SyntheticObservations} of $(keys(first(observations).field_time_serieses)) on $(summary(first(observations).grid))"
 
 tupleit(t) = try
     Tuple(t)
@@ -194,11 +194,12 @@ end
 #####
 
 """
-    column_ensemble_interior(observations::Vector{<:SyntheticObservations}, field_name, time_indices::Vector, N_ens)
+    column_ensemble_interior(observations::Vector{<:SyntheticObservations},
+                             field_name, time_index, (Nensemble, Nbatch, Nz))
 
 Return an `Nensemble × Nbatch × Nz` Array of `(1, 1, Nz)` `field_name` data,
-given `Nbatch` `SyntheticObservations` objects.
-The `Nbatch × Nz` data for `field_name` is copied `Nensemble` times to form a 3D Array.
+given `Nbatch` `SyntheticObservations` objects. The `Nbatch × Nz` data for `field_name`
+is copied `Nensemble` times to form a 3D Array.
 """
 function column_ensemble_interior(observations::Vector{<:SyntheticObservations},
                                   field_name, time_index, (Nensemble, Nbatch, Nz))

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1,5 +1,7 @@
 module Observations
 
+export SyntheticObservations, observation_times
+
 using Oceananigans
 using Oceananigans: fields
 using Oceananigans.Grids: AbstractGrid

--- a/src/OceanTurbulenceParameterEstimation.jl
+++ b/src/OceanTurbulenceParameterEstimation.jl
@@ -34,6 +34,14 @@ include("Parameters.jl")
 include("InverseProblems.jl")
 include("EnsembleKalmanInversions.jl")
 
+using .Utils
+using .Transformations
+using .Observations
+using .EnsembleSimulations
+using .Parameters
+using .InverseProblems
+using .EnsembleKalmanInversions
+
 #####
 ##### Data!
 #####

--- a/src/OceanTurbulenceParameterEstimation.jl
+++ b/src/OceanTurbulenceParameterEstimation.jl
@@ -34,26 +34,6 @@ include("Parameters.jl")
 include("InverseProblems.jl")
 include("EnsembleKalmanInversions.jl")
 
-using .Transformations: Transformation, ZScore, RescaledZScore, SpaceIndices, TimeIndices
-using .Observations: SyntheticObservations, observation_times
-using .EnsembleSimulations: ensemble_column_model_simulation
-using .Parameters: FreeParameters, lognormal, ScaledLogitNormal
-
-using .InverseProblems:
-    InverseProblem,
-    forward_map,
-    forward_run!,
-    observation_map,
-    observation_map_variance_across_time,
-    ConcatenatedOutputMap
-
-using .EnsembleKalmanInversions:
-    iterate!,
-    EnsembleKalmanInversion,
-    Resampler,
-    FullEnsembleDistribution,
-    SuccessfulEnsembleDistribution
-
 #####
 ##### Data!
 #####

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -481,14 +481,13 @@ function update_closure_ensemble_member!(closure_tuple::Tuple, p_ensemble, param
 end
 
 """
-    new_closure_ensemble(closures, θ, arch)
+    new_closure_ensemble(closures, θ, arch=CPU())
 
-Return a new set of `closures` in which all closures that have
-free parameters are updated. Closures with free parameters are
-expected as `Arrays` of `TurbulenceClosures`, and this allows
-`new_closure_ensemble` to go through all closures in `closures`
-and only update the parameters for the any closure that is of
-type `AbstractArray`.
+Return a new set of `closures` in which all closures that have free parameters are updated.
+Closures with free parameters are expected as `AbstractArray` of `TurbulenceClosures`, and
+this allows `new_closure_ensemble` to go through all closures in `closures` and only update
+the parameters for the any closure that is of type `AbstractArray`. The `arch`itecture
+(`CPU()` or `GPU()`) defines whethere `Array` or `CuArray` is returned.
 """
 function new_closure_ensemble(closures::AbstractArray, θ, arch)
     cpu_closures = arch_array(CPU(), closures)
@@ -501,6 +500,7 @@ function new_closure_ensemble(closures::AbstractArray, θ, arch)
 end
 new_closure_ensemble(closures::Tuple, θ, arch) = 
     Tuple(new_closure_ensemble(closure, θ, arch) for closure in closures)
+
 new_closure_ensemble(closure, θ, arch) = closure
 
 end # module

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1,5 +1,7 @@
 module Parameters
 
+export FreeParameters, lognormal, ScaledLogitNormal
+
 using Oceananigans.Architectures: CPU, arch_array, architecture
 using Oceananigans.TurbulenceClosures: AbstractTurbulenceClosure
 using Oceananigans.TurbulenceClosures: AbstractTimeDiscretization, ExplicitTimeDiscretization

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -1,5 +1,7 @@
 module Transformations
 
+export Transformation, ZScore, RescaledZScore, SpaceIndices, TimeIndices
+
 using Statistics
 
 using Oceananigans.Fields: interior

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -249,4 +249,3 @@ function transform_field_time_series(transformation::Transformation,
 end
 
 end # module
-


### PR DESCRIPTION
This way exported methods are shown at https://clima.github.io/OceanTurbulenceParameterEstimation.jl/previews/PR199/library/public/

(compare with https://clima.github.io/OceanTurbulenceParameterEstimation.jl/dev/library/public/)