### PR TITLE
Fix `prettyvector` which is used in `show(io, ::SyntheticObservations)`

### DIFF
--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -355,7 +355,7 @@ summarize_metadata(::Nothing) = ""
 summarize_metadata(metadata) = keys(metadata)
 
 function Base.show(io::IO, obs::SyntheticObservations)
-    times_str = prettyvector(prettytime.(obs.times, false), length(obs.times))
+    times_str = prettyvector(prettytime.(obs.times, false))
 
     print(io, "SyntheticObservations with fields $(propertynames(obs.field_time_serieses))", '\n',
               "├── times: $times_str", '\n',

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -355,7 +355,7 @@ summarize_metadata(::Nothing) = ""
 summarize_metadata(metadata) = keys(metadata)
 
 function Base.show(io::IO, obs::SyntheticObservations)
-    times_str = prettyvector(prettytime.(obs.times, false))
+    times_str = prettyvector(prettytime.(obs.times, false), length(obs.times))
 
     print(io, "SyntheticObservations with fields $(propertynames(obs.field_time_serieses))", '\n',
               "├── times: $times_str", '\n',

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -18,17 +18,26 @@ end
 
 function prettyvector(v::AbstractVector, bookends=3)
     separator = " … "
-    beginning = [string(v[i]) for i=1:bookends]
-    ending = [string(v[end+1-i]) for i=1:bookends]
-
-    for i = 1:bookends-1
-        beginning[i] *= ", "
-        ending[i] *= ", "
-    end
-
     N = length(v)
 
-    return string("[", beginning..., separator, ending..., "] ($N elements)")
+    if N < 2bookends + 2
+        content = string.(v) .* ", "
+        content = content[1:end-2]
+        return string("[", content..., "]")
+    else
+        separator = " … "
+        beginning = [string(v[i]) for i=1:bookends]
+        ending = [string(v[end+1-i]) for i=1:bookends]
+
+        for i = 1:bookends-1
+            beginning[i] *= ", "
+            ending[i] *= ", "
+        end
+
+        N = length(v)
+
+        return string("[", beginning..., separator, ending..., "] ($N elements)")
+    end
 end
 
 end # module

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -20,9 +20,9 @@ function prettyvector(v::AbstractVector, bookends=3)
     separator = " … "
     N = length(v)
 
-    if N < 2bookends + 2
+    if N < 2bookends + 4
         content = string.(v) .* ", "
-        content = content[1:end-2]
+        content[end] = content[end][1:end-2]
         return string("[", content..., "]")
     else
         separator = " … "

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("test_forward_map.jl")
 include("test_lesbrary_forward_map.jl")
 include("test_ensemble_column_models.jl")
 include("test_ensemble_kalman_inversion.jl")
+include("test_utils.jl")
 
 @testset "Doctests" begin
     using OceanTurbulenceParameterEstimation, Distributions

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -3,4 +3,4 @@ using OceanTurbulenceParameterEstimation
 using OceanTurbulenceParameterEstimation.Utils: prettyvector
 
 @test prettyvector([0, 1, 2]) == "[0, 1, 2]"
-@test prettyvector(collect(0:20)) == "[0, 1, 2 … 20, 19, 18] (21 elements)
+@test prettyvector(collect(0:20)) == "[0, 1, 2 … 20, 19, 18] (21 elements)"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,5 +2,5 @@ using Test
 using OceanTurbulenceParameterEstimation
 using OceanTurbulenceParameterEstimation.Utils: prettyvector
 
-@test prettyvector([0, 1, 2]) = "[0, 1, 2]"
-@test prettyvector(collect(0:20)) = "[0, 1, 2 … 20, 19, 18] (21 elements)
+@test prettyvector([0, 1, 2]) == "[0, 1, 2]"
+@test prettyvector(collect(0:20)) == "[0, 1, 2 … 20, 19, 18] (21 elements)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,6 @@
+using Test
+using OceanTurbulenceParameterEstimation
+using OceanTurbulenceParameterEstimation.Utils: prettyvector
+
+@test prettyvector([0, 1, 2]) = "[0, 1, 2]"
+@test prettyvector(collect(0:20)) = "[0, 1, 2 … 20, 19, 18] (21 elements)


### PR DESCRIPTION
Give `length` of `obs.times` to `prettyvector`.

```
julia> observations = SyntheticObservations(filepath; transformation, [0, 2hours], field_names)
SyntheticObservations with fields (:b, :c, :u)
├── times: [0 s, 2 hrs]
├── grid: 2048×256×80 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
├── path: "/Users/navid/Research/mesoscale-parametrization-OSM2022/baroclinic_adjustment-double_Lx/short_save_often_run/baroclinic_adjustment_double_Lx_zonal_average.jld2"
├── metadata: (:grid, :coriolis, :closure)
└── transformation: Dict{Symbol, Transformation{TimeIndices{UnitRange{Int64}}, Nothing, ZScore{Float64}}} with 3 entries

julia> observations = SyntheticObservations(filepath; transformation, times=0:2hours:30hours, field_names)
SyntheticObservations with fields (:b, :c, :u)
├── times: [0 s, 2 hrs, 4 hrs … 1.250 d, 1.167 d, 1.083 d] (16 elements)
├── grid: 2048×256×80 RectilinearGrid{Float64, Periodic, Bounded, Bounded} on CPU with 3×3×3 halo
├── path: "/Users/navid/Research/mesoscale-parametrization-OSM2022/baroclinic_adjustment-double_Lx/short_save_often_run/baroclinic_adjustment_double_Lx_zonal_average.jld2"
├── metadata: (:grid, :coriolis, :closure)
└── transformation: Dict{Symbol, Transformation{TimeIndices{UnitRange{Int64}}, Nothing, ZScore{Float64}}} with 3 entries
```