### PR TITLE
Zero out time series tendency data !!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OceanTurbulenceParameterEstimation"
 uuid = "eca81dc5-87a6-4430-aec8-c76695404a43"
 license = "MIT"
 authors = ["Adeline Hillier <adelineh2000@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <navidcy@gmail.com>", "and co-contributors"]
-version = "0.8.2"
+version = "0.9.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/EnsembleKalmanInversions.jl
+++ b/src/EnsembleKalmanInversions.jl
@@ -54,7 +54,12 @@ function construct_noise_covariance(noise_covariance::Number, y)
 end
     
 """
-    EnsembleKalmanInversion(inverse_problem; noise_covariance=1e-2, resampler=Resampler())
+    EnsembleKalmanInversion(inverse_problem;
+                            noise_covariance = 1e-2,
+                            resampler = Resampler(),
+                            unconstrained_parameters = nothing,
+                            forward_map_output = nothing,
+                            process = Inversion())
 
 Return an object that interfaces with
 [EnsembleKalmanProcesses.jl](https://github.com/CliMA/EnsembleKalmanProcesses.jl)

--- a/src/EnsembleKalmanInversions.jl
+++ b/src/EnsembleKalmanInversions.jl
@@ -97,7 +97,7 @@ Arguments
 
 - `resampler`: controls particle resampling procedure. See `Resampler`.
 """
-function EnsembleKalmanInversion(inverse_problem; noise_covariance=1e-2, resampler=Resampler())
+function EnsembleKalmanInversion(inverse_problem; noise_covariance=1e-2, resampler=Resampler(), unconstrained_parameters=nothing)
 
     free_parameters = inverse_problem.free_parameters
     priors = free_parameters.priors
@@ -118,7 +118,12 @@ function EnsembleKalmanInversion(inverse_problem; noise_covariance=1e-2, resampl
 
     # Generate an initial sample of parameters
     unconstrained_priors = NamedTuple(name => unconstrained_prior(priors[name]) for name in free_parameters.names)
-    Xᵢ = [rand(unconstrained_priors[i]) for i=1:Nθ, k=1:Nens]
+
+    if isnothing(unconstrained_parameters)
+        Xᵢ = [rand(unconstrained_priors[i]) for i=1:Nθ, k=1:Nens]
+    else
+        Xᵢ = unconstrained_parameters
+    end
 
     # Build EKP-friendly observations "y" and the covariance matrix of observational uncertainty "Γy"
     y = dropdims(observation_map(inverse_problem), dims=2) # length(forward_map_output) column vector

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -70,11 +70,14 @@ function InverseProblem(observations,
     return InverseProblem(observations, simulation, time_series_collector, free_parameters, output_map)
 end
 
+Base.summary(ip::InverseProblem) =
+    string("InverseProblem{", summary(ip.output_map), "} with free parameters ", ip.free_parameters.names)
+
 function Base.show(io::IO, ip::InverseProblem)
     sim_str = "Simulation on $(summary(ip.simulation.model.grid)) with Δt=$(ip.simulation.Δt)"
     out_map_str = summary(ip.output_map)
 
-    print(io, "InverseProblem{$out_map_str}", '\n',
+    print(io, summary(ip), '\n',
         "├── observations: $(summary(ip.observations))", '\n',
         "├── simulation: $sim_str", '\n',
         "├── free_parameters: $(summary(ip.free_parameters))", '\n',

--- a/src/InverseProblems.jl
+++ b/src/InverseProblems.jl
@@ -194,6 +194,13 @@ end
 
 (ip::InverseProblem)(θ) = forward_map(ip, θ)
 
+# Compute inverse transform from unconstrained (transformed) space to
+# constrained (physical) space
+function inverting_forward_map(ip::InverseProblem, X)
+    θ = transform_to_constrained(ip.free_parameters.priors, X)
+    return forward_map(ip, θ)
+end
+
 #####
 ##### ConcatenatedOutputMap
 #####

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -345,6 +345,9 @@ function initialize_forward_run!(simulation, observations, time_series_collector
     arch = architecture(time_series_collector.grid)
 
     # Clear potential NaNs from timestepper data.
+    # Particularly important for Adams-Bashforth timestepping scheme.
+    # Oceananigans ≤ v0.71 initializes the Adams-Bashforth scheme with an Euler step by *multiplying* the tendency
+    # at time-step n-1 by 0. Because 0 * NaN = NaN, this fails when the tendency at n-1 contains NaNs.
     timestepper = simulation.model.timestepper 
     for field in tuple(timestepper.Gⁿ..., timestepper.G⁻...)
         if !isnothing(field)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -9,7 +9,7 @@ using Oceananigans: fields
 using Oceananigans.Grids: AbstractGrid
 using Oceananigans.Grids: cpu_face_constructor_x, cpu_face_constructor_y, cpu_face_constructor_z
 using Oceananigans.Grids: pop_flat_elements, topology, halo_size, on_architecture
-using Oceananigans.TimeSteppers: update_state!
+using Oceananigans.TimeSteppers: update_state!, reset!
 using Oceananigans.Fields
 using Oceananigans.Utils: SpecifiedTimes, prettytime
 using Oceananigans.Architectures
@@ -308,7 +308,12 @@ function (collector::FieldTimeSeriesCollector)(simulation)
     end
 
     current_time = simulation.model.clock.time
-    time_index = findfirst(t -> t >= current_time, collector.times)
+    time_index = findfirst(t -> t ≈ current_time, collector.times)
+    if isnothing(time_index)
+        @warn string("Current time ", prettytime(current_time), " not found in
+                     time collector times ", prettytime.(collector.times))
+        return nothing
+    end
 
     for field_name in keys(collector.collected_fields)
         field_time_series = collector.field_time_serieses[field_name]
@@ -328,25 +333,36 @@ end
 ##### Initializing simulations
 #####
 
-function initialize_simulation!(simulation, observations, time_series_collector, time_index=1)
-    set!(simulation.model, observations, time_index)
+function initialize_forward_run!(simulation, observations, time_series_collector, time_index=1)
+
+    reset!(simulation)
 
     times = observation_times(observations)
     initial_time = times[time_index]
     simulation.model.clock.time = initial_time
-    simulation.model.clock.iteration = 0
-    simulation.model.timestepper.previous_Δt = Inf
-    simulation.initialized = false
 
+    collected_fields = time_series_collector.collected_fields
+    arch = architecture(time_series_collector.grid)
+
+    # Clear potential NaNs from timestepper data.
+    timestepper = simulation.model.timestepper 
+    for field in tuple(timestepper.Gⁿ..., timestepper.G⁻...)
+        if !isnothing(field)
+            parent(field) .= 0
+        end
+    end
+    
     # Zero out time series data
     for time_series in time_series_collector.field_time_serieses
         parent(time_series) .= 0
     end
 
-    simulation.callbacks[:data_collector] = Callback(time_series_collector, SpecifiedTimes(times...))
     :nan_checker ∈ keys(simulation.callbacks) && pop!(simulation.callbacks, :nan_checker)
-
+    :data_collector ∈ keys(simulation.callbacks) && pop!(simulation.callbacks, :data_collector)
+    simulation.callbacks[:data_collector] = Callback(time_series_collector, SpecifiedTimes(times...))
     simulation.stop_time = times[end]
+
+    set!(simulation.model, observations, time_index)
 
     return nothing
 end

--- a/test/test_ensemble_kalman_inversion.jl
+++ b/test/test_ensemble_kalman_inversion.jl
@@ -193,7 +193,7 @@ architecture = CPU()
             θ3 = deepcopy(θ[:, 3])
 
             # Fake a forward map output with NaNs
-            G = inverting_forward_map(eki, θ)
+            G = inverting_forward_map(eki.inverse_problem, θ)
             view(G, :, 1) .= NaN
             view(G, :, 2) .= NaN
 

--- a/test/test_ensemble_kalman_inversion.jl
+++ b/test/test_ensemble_kalman_inversion.jl
@@ -12,6 +12,7 @@ using OceanTurbulenceParameterEstimation
 using OceanTurbulenceParameterEstimation.EnsembleKalmanInversions: iterate!
 using OceanTurbulenceParameterEstimation.EnsembleKalmanInversions: FullEnsembleDistribution, Resampler
 using OceanTurbulenceParameterEstimation.EnsembleKalmanInversions: resample!, column_has_nan
+using OceanTurbulenceParameterEstimation.InverseProblems: inverting_forward_map
 
 data_path = "convective_adjustment_test.jld2"
 Nensemble = 3
@@ -111,7 +112,7 @@ architecture = CPU()
             θ3 = deepcopy(θ[:, 3])
 
             # Fake a forward map output with NaNs
-            G = eki.inverting_forward_map(θ)
+            G = inverting_forward_map(eki.inverse_problem, θ)
             view(G, :, 2) .= NaN
             @test any(isnan.(G)) == true
 
@@ -130,7 +131,7 @@ architecture = CPU()
             @test θ[:, 3] == θ3
 
             # Test that model fields get overwritten without NaN
-            G = eki.inverting_forward_map(θ)
+            G = inverting_forward_map(eki.inverse_problem, θ)
 
             # Particle 2
             view(G, :, 2) .= NaN
@@ -169,7 +170,7 @@ architecture = CPU()
             θ3 = deepcopy(θ[:, 3])
 
             # Fake a forward map output with NaNs
-            G = eki.inverting_forward_map(θ)
+            G = inverting_forward_map(eki.inverse_problem, θ)
             Gcopy = deepcopy(G)
 
             resample!(resampler, θ, G, eki)
@@ -192,7 +193,7 @@ architecture = CPU()
             θ3 = deepcopy(θ[:, 3])
 
             # Fake a forward map output with NaNs
-            G = eki.inverting_forward_map(θ)
+            G = inverting_forward_map(eki, θ)
             view(G, :, 1) .= NaN
             view(G, :, 2) .= NaN
 

--- a/test/test_forward_map.jl
+++ b/test/test_forward_map.jl
@@ -8,7 +8,7 @@ using Oceananigans.Grids: halo_size
 using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
 using Oceananigans.TurbulenceClosures: ConvectiveAdjustmentVerticalDiffusivity
 
-using OceanTurbulenceParameterEstimation.Observations: FieldTimeSeriesCollector, initialize_simulation!, observation_times
+using OceanTurbulenceParameterEstimation.Observations: FieldTimeSeriesCollector, initialize_forward_run!, observation_times
 using OceanTurbulenceParameterEstimation.InverseProblems: transpose_model_output, forward_run!, drop_y_dimension
 
 @testset "Unit tests for forward_map" begin
@@ -89,8 +89,8 @@ end
         collected_fields = (u = test_simulation.model.velocities.u, b = test_simulation.model.tracers.b)
         time_series_collector = FieldTimeSeriesCollector(collected_fields, observation_times(observations))
 
-        # Test initialize_simulation!
-        @info "  Testing initialize_simulation!..."
+        # Test initialize_forward_run!
+        @info "  Testing initialize_forward_run!..."
         random_initial_condition(x, y, z) = rand()
 
         for field in fields(test_simulation.model)
@@ -105,7 +105,7 @@ end
         @test !all(test_b .== 0)
 
         test_simulation.stop_iteration = Inf
-        initialize_simulation!(test_simulation, observations, time_series_collector)
+        initialize_forward_run!(test_simulation, observations, time_series_collector)
 
         @test all(test_v .== 0)
 
@@ -175,7 +175,7 @@ end
         test_simulation = build_simulation(column_ensemble_size)
         collected_fields = (u = test_simulation.model.velocities.u, b = test_simulation.model.tracers.b)
         time_series_collector = FieldTimeSeriesCollector(collected_fields, observation_times(observations))
-        initialize_simulation!(test_simulation, observations, time_series_collector)
+        initialize_forward_run!(test_simulation, observations, time_series_collector)
         run!(test_simulation)
         output = transpose_model_output(time_series_collector, observations)
 
@@ -199,7 +199,7 @@ end
         test_simulation = build_simulation(column_ensemble_size)
         collected_fields = (u = test_simulation.model.velocities.u, b = test_simulation.model.tracers.b)
         time_series_collector = FieldTimeSeriesCollector(collected_fields, observation_times(observations))
-        initialize_simulation!(test_simulation, observations_batch, time_series_collector)
+        initialize_forward_run!(test_simulation, observations_batch, time_series_collector)
         run!(test_simulation)
         output = transpose_model_output(time_series_collector, observations_batch)
 


### PR DESCRIPTION
This is necessary because NaNs will _persist_ otherwise. The reason is that Oceananigans initializes the Adams-Bashforth scheme with an Euler step by _multiplying the tendency at time-step n-1 by 0_. Because `0 * NaN = NaN`, this _fails_ when the tendency at `n-1` contains NaNs.

This PR also zeros out the tendency at time-step `n`, because conservatism and wow.

We may also want to fix this problem in Oceananigans. I think by far the simplest solution is to _explicitly_ take an Euler step, rather than using a "multiply by 0" hack. But that's a conversation to have over at Oceananigans.jl.

This PR also makes a few cosmetic changes but nothing else substantial. Mainly there's a new interface for initializing EKI with previously obtained forward map output and parameters. This was convenient for debugging this problem and seems fine enough to keep.

